### PR TITLE
feat: add @world2agent/sensor-github-trending

### DIFF
--- a/sensors/sensor-github-trending/.gitignore
+++ b/sensors/sensor-github-trending/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+*.tsbuildinfo

--- a/sensors/sensor-github-trending/.gitignore
+++ b/sensors/sensor-github-trending/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 *.tsbuildinfo
+*.tgz

--- a/sensors/sensor-github-trending/README.md
+++ b/sensors/sensor-github-trending/README.md
@@ -1,0 +1,39 @@
+# @world2agent/sensor-github-trending
+
+A [W2A](https://world2agent.ai) sensor that emits a periodic digest of trending repositories on https://github.com/trending.
+
+- **Source:** github.com/trending (public HTML, no auth)
+- **Cadence:** `daily` or `weekly` (default `weekly`)
+- **Signal type:** `repo.trending.refreshed`
+- **Shape:** one digest signal per cycle, containing the top N repos in `source_event.data.repos` plus a pre-formatted markdown digest as the first attachment.
+
+## Install
+
+In Claude Code:
+
+```
+/world2agent:sensor-add @world2agent/sensor-github-trending
+```
+
+The install flow runs the [`SETUP.md`](./SETUP.md) Q&A — three defaulted questions for cadence / top_n / dedupe.
+
+## Standalone CLI
+
+```bash
+npm install -g @world2agent/sensor-github-trending
+W2A_CONFIG='{"cadence":"weekly","top_n":10}' w2a-sensor-github-trending
+```
+
+Each emit is a JSON-encoded `W2ASignal` written to stdout.
+
+## Config
+
+| Field                  | Default    | Notes                                                    |
+| ---------------------- | ---------- | -------------------------------------------------------- |
+| `cadence`              | `"weekly"` | `"daily"` or `"weekly"`                                  |
+| `top_n`                | `10`       | 1–25                                                     |
+| `dedupe_within_cycles` | `0`        | Skip repos seen in the last N digests; `0` = always send |
+
+## License
+
+Apache-2.0

--- a/sensors/sensor-github-trending/SETUP.md
+++ b/sensors/sensor-github-trending/SETUP.md
@@ -74,9 +74,9 @@ description: Handle GitHub Trending digest signals (repo.trending.refreshed). Us
 
 ## Signal Shape
 - `event.type`: `repo.trending.refreshed`
-- `event.summary`: lead repo, top 3 sample, dominant languages, star delta on the lead.
+- `event.summary`: multi-line, emoji-rich. Header line + per-repo line (rank emoji, name link, language, ⭐ delta, heat badge) + one-line blurb under each. An agent reading only the summary can already triage; deeper reasoning lives in `attachments[0]`.
 - `source_event.data`: `{ window, captured_at, source_url, repo_count, repos[] }`. Each repo entry carries `{ rank, full_name, url, description, language, stars_total, stars_gained_in_window, forks }`.
-- `attachments[0]` (inline `text/markdown`): pre-formatted human-readable digest of the top N repos. Read this first.
+- `attachments[0]` (inline `text/markdown`): rich digest — per-repo section with description quote, "Why it's hot" reasoning (derived from star ratios), "Use it for" category hint, and the canonical URL. Read this when the user wants details on a specific repo.
 - `attachments[1]` (reference `text/html`): live github.com/trending URL. Fetch only if the inline digest is stale or insufficient.
 
 ## Priority & Handling

--- a/sensors/sensor-github-trending/SETUP.md
+++ b/sensors/sensor-github-trending/SETUP.md
@@ -1,0 +1,95 @@
+# GitHub Trending Sensor Setup
+
+This sensor scrapes https://github.com/trending on a daily or weekly cadence and emits one digest signal per cycle (`repo.trending.refreshed`) carrying the top N repos with their star deltas, languages, and descriptions. No GitHub authentication is required — the trending page is public.
+
+## Configuration Parameters (written to `~/.world2agent/config.json`)
+
+| Parameter              | Type                | Required | Default    | Description                                                                                       |
+| ---------------------- | ------------------- | -------- | ---------- | ------------------------------------------------------------------------------------------------- |
+| `cadence`              | `"daily" \| "weekly"` | No       | `"weekly"` | How often to fetch and emit, and which `since=` window to scrape.                                |
+| `top_n`                | integer (1–25)      | No       | `10`       | How many repos to include in each digest.                                                        |
+| `dedupe_within_cycles` | integer (0–52)      | No       | `0`        | If > 0, repos seen in any of the last N digests are skipped. `0` means always send (recommended). |
+
+## Questions to Ask
+
+### 1. Config questions (populate the sensor config)
+
+Ask in one prompt, all defaulted:
+
+> "GitHub Trending digest — three optional settings:
+>
+> 1. Cadence: daily or weekly? (default: weekly)
+> 2. How many top repos per digest? (default: 10, max 25)
+> 3. Skip repos that already appeared in the last N digests? Enter a number, or 0 to always send. (default: 0)
+>
+> Press Enter at any prompt to keep the default."
+
+### 2. Semantic preferences (populate the handler skill)
+
+> "When a new GitHub Trending digest arrives:
+>
+> 1. What topics or languages do you most care about? (e.g. AI/LLM, TypeScript, Rust, devtools, security) — used to highlight relevant repos.
+> 2. For repos you care about: just summarise, open the repo URL, draft a quick PR/issue comment, or save to a reading list?
+> 3. Anything to ignore? (e.g. crypto, LeetCode solutions, sketchy starred-by-bot repos)"
+
+## Output
+
+### 1. Write `~/.world2agent/config.json`
+
+```json
+{
+  "sensors": [
+    {
+      "package": "@world2agent/sensor-github-trending",
+      "config": {
+        "cadence": "weekly",
+        "top_n": 10,
+        "dedupe_within_cycles": 0
+      },
+      "skills": ["<absolute path to the handler skill's directory from §2>"]
+    }
+  ]
+}
+```
+
+### 2. Write the handler skill
+
+Skill filename and frontmatter `name:` MUST be `world2agent-sensor-github-trending` (= `packageToSkillId("@world2agent/sensor-github-trending")`).
+
+Template:
+
+```markdown
+---
+name: world2agent-sensor-github-trending
+user-invocable: false
+description: Handle GitHub Trending digest signals (repo.trending.refreshed). User cares about [USER_TOPICS].
+---
+
+# GitHub Trending Signal Handler
+
+## User Preferences
+- Topics of interest: [USER_TOPICS]
+- Action style for relevant repos: [USER_ACTION]
+- Ignore: [USER_SKIP_POLICY]
+
+## Signal Shape
+- `event.type`: `repo.trending.refreshed`
+- `event.summary`: lead repo, top 3 sample, dominant languages, star delta on the lead.
+- `source_event.data`: `{ window, captured_at, source_url, repo_count, repos[] }`. Each repo entry carries `{ rank, full_name, url, description, language, stars_total, stars_gained_in_window, forks }`.
+- `attachments[0]` (inline `text/markdown`): pre-formatted human-readable digest of the top N repos. Read this first.
+- `attachments[1]` (reference `text/html`): live github.com/trending URL. Fetch only if the inline digest is stale or insufficient.
+
+## Priority & Handling
+- Default urgency: informational.
+- For each repo in `source_event.data.repos`:
+  - If it matches `[USER_TOPICS]`, surface it per `[USER_ACTION]`.
+  - If it matches `[USER_SKIP_POLICY]`, drop silently.
+  - Otherwise: include in a one-line tail summary so the user can scan the rest.
+- Never paginate or fetch GitHub repo metadata unless the user explicitly asks — `source_event.data` already has what's needed for triage.
+```
+
+## Before writing
+
+1. Show the proposed `config.json` and handler skill to the user for confirmation.
+2. Resolve the handler-skill directory (runtime-dependent — consult the agent's skills discovery rules).
+3. Write the handler skill, record its directory's absolute path, and write that path into the `skills` array of `config.json`.

--- a/sensors/sensor-github-trending/package-lock.json
+++ b/sensors/sensor-github-trending/package-lock.json
@@ -1,0 +1,377 @@
+{
+  "name": "@world2agent/sensor-github-trending",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@world2agent/sensor-github-trending",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@world2agent/sdk": "^0.1.0-alpha.1",
+        "cheerio": "^1.0.0",
+        "zod": "^3.25.0"
+      },
+      "bin": {
+        "w2a-sensor-github-trending": "dist/bin.js"
+      },
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+        "typescript": "^5.8.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@world2agent/sdk": {
+      "version": "0.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@world2agent/sdk/-/sdk-0.1.0-alpha.1.tgz",
+      "integrity": "sha512-YfCdXPyX9Zm811fsT0kiTfCRW7iOZ4ByYZCwlqeKZbXRy8/RxJrse6KGzexfZWAXv0L8Gl8ZvOJTs4WesfIiaQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/sensors/sensor-github-trending/package.json
+++ b/sensors/sensor-github-trending/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@world2agent/sensor-github-trending",
+  "version": "0.1.0",
+  "description": "W2A sensor — periodic digest of trending repositories on GitHub (daily or weekly).",
+  "keywords": [
+    "world2agent",
+    "w2a",
+    "w2a-sensor",
+    "sensor",
+    "agent",
+    "github",
+    "trending"
+  ],
+  "license": "Apache-2.0",
+  "author": "MachinePulse AI",
+  "homepage": "https://github.com/machinepulse-ai/world2agent",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/machinepulse-ai/world2agent.git",
+    "directory": "sensors/sensor-github-trending"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" }
+  },
+  "bin": { "w2a-sensor-github-trending": "./dist/bin.js" },
+  "scripts": {
+    "start": "node dist/bin.js",
+    "build": "tsc --build",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "smoke": "node dist/smoke.js"
+  },
+  "dependencies": {
+    "@world2agent/sdk": "^0.1.0-alpha.1",
+    "cheerio": "^1.0.0",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "typescript": "^5.8.0"
+  },
+  "files": ["dist", "SETUP.md", "README.md"],
+  "engines": { "node": ">=20" },
+  "w2a": {
+    "type": "sensor",
+    "source_type": "github",
+    "signals": ["repo.trending.refreshed"],
+    "setup": "./SETUP.md"
+  }
+}

--- a/sensors/sensor-github-trending/src/bin.ts
+++ b/sensors/sensor-github-trending/src/bin.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import { run } from "@world2agent/sdk/consumer";
+import sensor from "./index.js";
+
+await run(sensor);

--- a/sensors/sensor-github-trending/src/fetch-trending.ts
+++ b/sensors/sensor-github-trending/src/fetch-trending.ts
@@ -1,0 +1,80 @@
+import * as cheerio from "cheerio";
+import type { TrendingRepo } from "./types.js";
+
+const TRENDING_URL = "https://github.com/trending";
+
+export async function fetchTrending(
+  window: "daily" | "weekly",
+  topN: number,
+): Promise<TrendingRepo[]> {
+  const url = `${TRENDING_URL}?since=${window}`;
+  const res = await fetch(url, {
+    headers: {
+      "user-agent":
+        "Mozilla/5.0 (compatible; w2a-sensor-github-trending/0.1.0; +https://world2agent.ai)",
+      accept: "text/html,application/xhtml+xml",
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`github.com/trending returned ${res.status} ${res.statusText}`);
+  }
+  return parseTrendingHtml(await res.text(), topN);
+}
+
+export function parseTrendingHtml(html: string, topN: number): TrendingRepo[] {
+  const $ = cheerio.load(html);
+  const repos: TrendingRepo[] = [];
+
+  $("article.Box-row").each((index, el) => {
+    if (repos.length >= topN) return false;
+
+    const $el = $(el);
+    const titleAnchor = $el.find("h2.h3.lh-condensed a").first();
+    const href = (titleAnchor.attr("href") ?? "").trim();
+    if (!href || !href.startsWith("/")) return;
+
+    const fullName = href.slice(1);
+    const [author, name] = fullName.split("/");
+    if (!author || !name) return;
+
+    const description = $el.find("p.col-9").first().text().trim();
+    const language =
+      $el.find('[itemprop="programmingLanguage"]').first().text().trim() || null;
+
+    const starsTotal = parseIntCommaSafe(
+      $el.find(`a[href="/${fullName}/stargazers"]`).first().text(),
+    );
+    const forks = parseIntCommaSafe(
+      $el.find(`a[href="/${fullName}/forks"]`).first().text(),
+    );
+
+    let starsGained = 0;
+    $el.find("span.d-inline-block.float-sm-right").each((_, span) => {
+      const t = $(span).text().trim();
+      const m = t.match(/([\d,]+)\s+stars?/i);
+      if (m) starsGained = parseIntCommaSafe(m[1]);
+    });
+
+    repos.push({
+      rank: index + 1,
+      full_name: fullName,
+      author,
+      name,
+      url: `https://github.com/${fullName}`,
+      description,
+      language,
+      stars_total: starsTotal,
+      stars_gained_in_window: starsGained,
+      forks,
+    });
+    return;
+  });
+
+  return repos;
+}
+
+function parseIntCommaSafe(s: string): number {
+  const cleaned = s.replace(/[,\s]/g, "");
+  const n = Number.parseInt(cleaned, 10);
+  return Number.isFinite(n) ? n : 0;
+}

--- a/sensors/sensor-github-trending/src/index.ts
+++ b/sensors/sensor-github-trending/src/index.ts
@@ -1,0 +1,17 @@
+import { defineSensor } from "@world2agent/sdk/sensor";
+import { start } from "./start.js";
+import { githubTrendingConfigSchema } from "./types.js";
+
+export default defineSensor({
+  id: "@world2agent/sensor-github-trending",
+  version: "0.1.0",
+  source_type: "github",
+  auth: { type: "none" },
+  configSchema: githubTrendingConfigSchema,
+  start,
+});
+
+export { transformTrendingDigest } from "./transform.js";
+export { fetchTrending, parseTrendingHtml } from "./fetch-trending.js";
+export { githubTrendingConfigSchema } from "./types.js";
+export type { GithubTrendingConfig, TrendingRepo } from "./types.js";

--- a/sensors/sensor-github-trending/src/smoke.ts
+++ b/sensors/sensor-github-trending/src/smoke.ts
@@ -1,0 +1,31 @@
+/**
+ * Smoke test: run the sensor against live github.com/trending once,
+ * print the resulting signal, then exit. No scheduling, no install flow.
+ *
+ *   pnpm build && pnpm smoke
+ *   pnpm build && pnpm smoke -- --cadence daily --top_n 5
+ */
+import { fetchTrending } from "./fetch-trending.js";
+import { transformTrendingDigest } from "./transform.js";
+
+function arg(name: string, fallback: string): string {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+const cadence = arg("cadence", "weekly") as "daily" | "weekly";
+const topN = Number.parseInt(arg("top_n", "10"), 10);
+
+if (cadence !== "daily" && cadence !== "weekly") {
+  console.error(`invalid --cadence ${cadence}; must be 'daily' or 'weekly'`);
+  process.exit(2);
+}
+
+const repos = await fetchTrending(cadence, topN);
+const signal = transformTrendingDigest({
+  window: cadence,
+  capturedAt: Date.now(),
+  repos,
+});
+
+process.stdout.write(JSON.stringify(signal, null, 2) + "\n");

--- a/sensors/sensor-github-trending/src/start.ts
+++ b/sensors/sensor-github-trending/src/start.ts
@@ -1,0 +1,115 @@
+import { ensureStore } from "@world2agent/sdk";
+import type { CleanupFn, SensorContext } from "@world2agent/sdk";
+import { fetchTrending } from "./fetch-trending.js";
+import { transformTrendingDigest } from "./transform.js";
+import type { GithubTrendingConfig, TrendingRepo } from "./types.js";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const SEEN_KEY = "seen_repos";
+
+interface SeenEntry {
+  repo: string;
+  cycle: number;
+}
+
+export async function start(
+  ctx: SensorContext<GithubTrendingConfig>,
+): Promise<CleanupFn> {
+  const { cadence, top_n, dedupe_within_cycles } = ctx.config;
+  const intervalMs = cadence === "daily" ? MS_PER_DAY : 7 * MS_PER_DAY;
+  const store = ensureStore(ctx);
+
+  let cycle = await readCycle(store);
+  let stopped = false;
+  let timer: NodeJS.Timeout | undefined;
+
+  async function tick() {
+    if (stopped) return;
+    cycle += 1;
+    try {
+      const fetched = await fetchTrending(cadence, /* over-fetch for dedupe */ 25);
+      const filtered = await filterSeen(store, fetched, dedupe_within_cycles, cycle);
+      const repos = filtered.slice(0, top_n).map((r, i) => ({ ...r, rank: i + 1 }));
+
+      const signal = transformTrendingDigest({
+        window: cadence,
+        capturedAt: Date.now(),
+        repos,
+      });
+      await ctx.emit(signal);
+      await recordSeen(store, repos, dedupe_within_cycles, cycle);
+      await writeCycle(store, cycle);
+      ctx.reportHealth("ok");
+    } catch (err) {
+      ctx.logger.error("github-trending tick failed", err);
+      ctx.reportHealth("degraded", err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  // First emit on start, then on the cadence interval.
+  void tick();
+  timer = setInterval(tick, intervalMs);
+
+  return () => {
+    stopped = true;
+    if (timer) clearInterval(timer);
+  };
+}
+
+async function readCycle(store: { get(k: string): Promise<string | null> }): Promise<number> {
+  const raw = await store.get("cycle");
+  const n = raw ? Number.parseInt(raw, 10) : 0;
+  return Number.isFinite(n) ? n : 0;
+}
+
+async function writeCycle(
+  store: { set(k: string, v: string): Promise<void> },
+  cycle: number,
+): Promise<void> {
+  await store.set("cycle", String(cycle));
+}
+
+async function filterSeen(
+  store: { get(k: string): Promise<string | null> },
+  repos: TrendingRepo[],
+  dedupeCycles: number,
+  currentCycle: number,
+): Promise<TrendingRepo[]> {
+  if (dedupeCycles <= 0) return repos;
+  const raw = await store.get(SEEN_KEY);
+  if (!raw) return repos;
+  let seen: SeenEntry[];
+  try {
+    seen = JSON.parse(raw) as SeenEntry[];
+  } catch {
+    return repos;
+  }
+  const cutoff = currentCycle - dedupeCycles;
+  const blocked = new Set(seen.filter((e) => e.cycle > cutoff).map((e) => e.repo));
+  return repos.filter((r) => !blocked.has(r.full_name));
+}
+
+async function recordSeen(
+  store: {
+    get(k: string): Promise<string | null>;
+    set(k: string, v: string): Promise<void>;
+  },
+  repos: TrendingRepo[],
+  dedupeCycles: number,
+  currentCycle: number,
+): Promise<void> {
+  if (dedupeCycles <= 0) return;
+  const raw = await store.get(SEEN_KEY);
+  let seen: SeenEntry[] = [];
+  if (raw) {
+    try {
+      seen = JSON.parse(raw) as SeenEntry[];
+    } catch {
+      seen = [];
+    }
+  }
+  const cutoff = currentCycle - dedupeCycles;
+  const kept = seen.filter((e) => e.cycle > cutoff);
+  for (const r of repos) kept.push({ repo: r.full_name, cycle: currentCycle });
+  await store.set(SEEN_KEY, JSON.stringify(kept));
+}

--- a/sensors/sensor-github-trending/src/transform.ts
+++ b/sensors/sensor-github-trending/src/transform.ts
@@ -1,0 +1,178 @@
+import { createSignal, type W2ASignal } from "@world2agent/sdk";
+import type { TrendingRepo } from "./types.js";
+
+const SENSOR_META = {
+  id: "@world2agent/sensor-github-trending",
+  version: "0.1.0",
+  source_type: "github",
+} as const;
+
+export interface DigestInput {
+  window: "daily" | "weekly";
+  capturedAt: number;
+  repos: TrendingRepo[];
+}
+
+export function transformTrendingDigest(input: DigestInput): W2ASignal {
+  const { window, capturedAt, repos } = input;
+  const windowLabel = window === "daily" ? "today" : "this week";
+
+  const summary = buildSummary(window, windowLabel, repos);
+  const markdown = buildMarkdown(window, windowLabel, repos);
+
+  return createSignal(SENSOR_META, {
+    source: { user_identity: "public" },
+    event: {
+      type: "repo.trending.refreshed",
+      occurred_at: capturedAt,
+      summary,
+    },
+    source_event: {
+      schema: {
+        type: "object",
+        properties: {
+          window: {
+            type: "string",
+            enum: ["daily", "weekly"],
+            description: "Trending window: 'daily' = past 24h, 'weekly' = past 7 days.",
+          },
+          captured_at: {
+            type: "string",
+            format: "date-time",
+            description: "When the trending page was scraped (ISO-8601 UTC).",
+          },
+          source_url: {
+            type: "string",
+            format: "uri",
+            description: "The github.com/trending URL the digest was scraped from.",
+          },
+          repo_count: {
+            type: "integer",
+            description: "Number of repos included in this digest (top_n).",
+          },
+          repos: {
+            type: "array",
+            description:
+              "Trending repos in rank order (rank 1 = top of the list on github.com/trending).",
+            items: {
+              type: "object",
+              properties: {
+                rank: {
+                  type: "integer",
+                  description: "1-based position on the trending page (1 = top).",
+                },
+                full_name: {
+                  type: "string",
+                  description: 'Repo full name in "owner/name" form, e.g. "vercel/next.js".',
+                },
+                author: { type: "string", description: "Repo owner (user or org)." },
+                name: { type: "string", description: "Repo name without the owner prefix." },
+                url: {
+                  type: "string",
+                  format: "uri",
+                  description: "Canonical https://github.com/<owner>/<name> URL.",
+                },
+                description: {
+                  type: "string",
+                  description: "Repo description as shown on the trending page (may be empty).",
+                },
+                language: {
+                  type: ["string", "null"],
+                  description:
+                    "Primary programming language as labelled by GitHub, or null when unknown.",
+                },
+                stars_total: {
+                  type: "integer",
+                  description: "Total stargazer count at scrape time.",
+                },
+                stars_gained_in_window: {
+                  type: "integer",
+                  description:
+                    "Stars gained during the current trending window (24h for daily, 7d for weekly).",
+                },
+                forks: { type: "integer", description: "Total fork count at scrape time." },
+              },
+              required: [
+                "rank",
+                "full_name",
+                "author",
+                "name",
+                "url",
+                "stars_total",
+                "stars_gained_in_window",
+                "forks",
+              ],
+            },
+          },
+        },
+        required: ["window", "captured_at", "source_url", "repo_count", "repos"],
+      },
+      data: {
+        window,
+        captured_at: new Date(capturedAt).toISOString(),
+        source_url: `https://github.com/trending?since=${window}`,
+        repo_count: repos.length,
+        repos,
+      },
+    },
+    attachments: [
+      {
+        type: "inline",
+        mime_type: "text/markdown",
+        description: `Human-readable digest of the top ${repos.length} ${window} trending GitHub repos with descriptions, languages, and star deltas.`,
+        data: markdown,
+      },
+      {
+        type: "reference",
+        mime_type: "text/html",
+        description: `Live github.com/trending page (${window} window) — fetch on demand for a fresh view.`,
+        uri: `https://github.com/trending?since=${window}`,
+      },
+    ],
+  });
+}
+
+function buildSummary(
+  window: "daily" | "weekly",
+  windowLabel: string,
+  repos: TrendingRepo[],
+): string {
+  if (repos.length === 0) {
+    return `GitHub Trending ${window} digest: no repos returned by github.com/trending; the scraper may need updating.`;
+  }
+  const lead = repos[0];
+  const sample = repos
+    .slice(0, Math.min(3, repos.length))
+    .map((r) => r.full_name)
+    .join(", ");
+  const langs = uniqueLanguages(repos).slice(0, 3).join(", ") || "mixed languages";
+  return `GitHub Trending ${window} digest: top ${repos.length} repos (${sample}…) led by ${lead.full_name} (+${lead.stars_gained_in_window.toLocaleString()} stars ${windowLabel}); covers ${langs}.`;
+}
+
+function buildMarkdown(
+  window: "daily" | "weekly",
+  windowLabel: string,
+  repos: TrendingRepo[],
+): string {
+  const header = `# GitHub Trending — ${window} digest\n\nTop ${repos.length} repos on https://github.com/trending?since=${window}.\n\n`;
+  const body = repos
+    .map((r) => {
+      const lang = r.language ? ` · ${r.language}` : "";
+      const desc = r.description ? `\n  ${r.description}` : "";
+      return `${r.rank}. **[${r.full_name}](${r.url})** — ★ ${r.stars_total.toLocaleString()} (+${r.stars_gained_in_window.toLocaleString()} ${windowLabel}) · ⑂ ${r.forks.toLocaleString()}${lang}${desc}`;
+    })
+    .join("\n");
+  return header + body + "\n";
+}
+
+function uniqueLanguages(repos: TrendingRepo[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const r of repos) {
+    if (r.language && !seen.has(r.language)) {
+      seen.add(r.language);
+      out.push(r.language);
+    }
+  }
+  return out;
+}

--- a/sensors/sensor-github-trending/src/transform.ts
+++ b/sensors/sensor-github-trending/src/transform.ts
@@ -138,15 +138,42 @@ function buildSummary(
   repos: TrendingRepo[],
 ): string {
   if (repos.length === 0) {
-    return `GitHub Trending ${window} digest: no repos returned by github.com/trending; the scraper may need updating.`;
+    return `🔥 GitHub Trending — no repos returned by github.com/trending?since=${window}; the scraper may need updating.`;
   }
   const lead = repos[0];
-  const sample = repos
-    .slice(0, Math.min(3, repos.length))
-    .map((r) => r.full_name)
-    .join(", ");
-  const langs = uniqueLanguages(repos).slice(0, 3).join(", ") || "mixed languages";
-  return `GitHub Trending ${window} digest: top ${repos.length} repos (${sample}…) led by ${lead.full_name} (+${lead.stars_gained_in_window.toLocaleString()} stars ${windowLabel}); covers ${langs}.`;
+  const dateStr = formatDate(new Date());
+  const langSummary =
+    uniqueLanguages(repos)
+      .slice(0, 4)
+      .map((l) => `${langEmoji(l)} ${l}`)
+      .join(" · ") || "mixed languages";
+
+  const lines: string[] = [];
+  lines.push(
+    `🔥 GitHub Trending — ${capitalise(window)} Digest (${dateStr}) · top ${repos.length}`,
+  );
+  lines.push(
+    `📊 Lead: ${lead.full_name} +${lead.stars_gained_in_window.toLocaleString()} ⭐ ${windowLabel} · ${langSummary}`,
+  );
+  lines.push("");
+  for (const r of repos) {
+    lines.push(formatRepoLine(r, windowLabel));
+  }
+  lines.push("");
+  lines.push(`🔗 Full live list: https://github.com/trending?since=${window}`);
+  return lines.join("\n");
+}
+
+function formatRepoLine(r: TrendingRepo, windowLabel: string): string {
+  const langTag = r.language ? `${langEmoji(r.language)} ${r.language}` : "🧩 unknown";
+  const heat = heatBadge(r);
+  const blurb = oneLineBlurb(r);
+  // Two-line per repo: header (rank + name + stats + heat) and indented blurb.
+  // `[name](url)` makes the link clickable in any markdown renderer.
+  return [
+    `${rankEmoji(r.rank)} **[${r.full_name}](${r.url})** · ${langTag} · ⭐ ${r.stars_total.toLocaleString()} (+${r.stars_gained_in_window.toLocaleString()} ${windowLabel}) · ${heat}`,
+    `   ↳ ${blurb}`,
+  ].join("\n");
 }
 
 function buildMarkdown(
@@ -154,15 +181,180 @@ function buildMarkdown(
   windowLabel: string,
   repos: TrendingRepo[],
 ): string {
-  const header = `# GitHub Trending — ${window} digest\n\nTop ${repos.length} repos on https://github.com/trending?since=${window}.\n\n`;
-  const body = repos
-    .map((r) => {
-      const lang = r.language ? ` · ${r.language}` : "";
-      const desc = r.description ? `\n  ${r.description}` : "";
-      return `${r.rank}. **[${r.full_name}](${r.url})** — ★ ${r.stars_total.toLocaleString()} (+${r.stars_gained_in_window.toLocaleString()} ${windowLabel}) · ⑂ ${r.forks.toLocaleString()}${lang}${desc}`;
-    })
-    .join("\n");
-  return header + body + "\n";
+  const dateStr = formatDate(new Date());
+  const langSummary =
+    uniqueLanguages(repos)
+      .slice(0, 6)
+      .map((l) => `${langEmoji(l)} ${l}`)
+      .join(" · ") || "mixed";
+
+  const out: string[] = [];
+  out.push(`# 🔥 GitHub Trending — ${capitalise(window)} Digest`);
+  out.push(``);
+  out.push(`📅 **${dateStr}** · top ${repos.length} on github.com/trending?since=${window}`);
+  out.push(`🏷️ **Languages:** ${langSummary}`);
+  out.push(``);
+  out.push(`---`);
+  out.push(``);
+
+  for (const r of repos) {
+    const langTag = r.language ? `${langEmoji(r.language)} ${r.language}` : "🧩 unknown";
+    const heat = heatBadge(r);
+    const useCase = useCaseHint(r);
+    const whyHot = whyHotReason(r, windowLabel);
+
+    out.push(
+      `## ${rankEmoji(r.rank)} [${r.full_name}](${r.url})`,
+    );
+    out.push(``);
+    out.push(
+      `${langTag} · ⭐ **${r.stars_total.toLocaleString()}** (+${r.stars_gained_in_window.toLocaleString()} ${windowLabel}) · ⑂ ${r.forks.toLocaleString()} · ${heat}`,
+    );
+    out.push(``);
+    if (r.description) {
+      out.push(`> ${r.description}`);
+      out.push(``);
+    }
+    out.push(`- 🚀 **Why it's hot:** ${whyHot}`);
+    out.push(`- 🛠️ **Use it for:** ${useCase}`);
+    out.push(`- 🔗 ${r.url}`);
+    out.push(``);
+  }
+
+  return out.join("\n");
+}
+
+/* ──────────────────────────────────────────────────────────── */
+/*  Heuristics — derived from data we already have, no extra    */
+/*  network calls. Cheap, deterministic, good enough for triage.*/
+/* ──────────────────────────────────────────────────────────── */
+
+function heatBadge(r: TrendingRepo): string {
+  if (r.stars_total === 0) return "🆕 brand new";
+  const ratio = r.stars_gained_in_window / r.stars_total;
+  if (ratio > 0.5) return "🆕 brand new (most stars came this window)";
+  if (ratio > 0.15) return "🚀 surging";
+  if (r.stars_total >= 50_000) return "🏆 established giant trending again";
+  if (r.stars_gained_in_window >= 1_000) return "📈 strong momentum";
+  return "📈 climbing";
+}
+
+function whyHotReason(r: TrendingRepo, windowLabel: string): string {
+  const ratio = r.stars_total > 0 ? r.stars_gained_in_window / r.stars_total : 0;
+  if (ratio > 0.5) {
+    return `New project — ${Math.round(ratio * 100)}% of total stars (${r.stars_gained_in_window.toLocaleString()} of ${r.stars_total.toLocaleString()}) were earned ${windowLabel}.`;
+  }
+  if (ratio > 0.15) {
+    return `Strong momentum — gained ${r.stars_gained_in_window.toLocaleString()} stars (${Math.round(ratio * 100)}% relative growth) ${windowLabel}.`;
+  }
+  if (r.stars_total >= 50_000) {
+    return `Long-running project resurfacing — ${r.stars_gained_in_window.toLocaleString()} new stars on top of ${r.stars_total.toLocaleString()} total ${windowLabel}.`;
+  }
+  return `Steady climb — ${r.stars_gained_in_window.toLocaleString()} stars ${windowLabel} (${r.stars_total.toLocaleString()} total).`;
+}
+
+/**
+ * Best-effort one-line "what is this" for `event.summary`. Falls back to
+ * the GitHub description. Only enrich when description is empty/short.
+ */
+function oneLineBlurb(r: TrendingRepo): string {
+  const desc = (r.description || "").trim();
+  if (desc.length >= 30) return truncate(desc, 160);
+  const cat = categoryHint(r);
+  if (desc) return `${desc} (${cat})`;
+  return cat;
+}
+
+/**
+ * What you might do with it — heuristic from name + description + language.
+ * The agent should still reason from the README; this is a triage hint.
+ */
+function useCaseHint(r: TrendingRepo): string {
+  const cat = categoryHint(r);
+  const desc = (r.description || "").trim();
+  if (desc) return `${cat}. ${truncate(desc, 200)}`;
+  return cat;
+}
+
+function categoryHint(r: TrendingRepo): string {
+  const text = `${r.name} ${r.description ?? ""}`.toLowerCase();
+  const has = (...words: string[]) => words.some((w) => text.includes(w));
+
+  if (has("agent", "autonom", "claude", "gpt-", "llm", "rag")) {
+    return "AI agent / LLM tooling — wire into your agent stack or study the prompts";
+  }
+  if (has("model", "transformer", "diffusion", "training", "fine-tun", "inference")) {
+    return "ML model / training infra — reference for model engineering";
+  }
+  if (has("framework", "library", "sdk", "toolkit")) {
+    return "Dev framework / SDK — drop-in dependency";
+  }
+  if (has("cli", "terminal", "tui")) {
+    return "CLI / terminal tool — install and use directly";
+  }
+  if (has("api", "server", "gateway", "proxy", "middleware")) {
+    return "Backend / API service — self-host or study the architecture";
+  }
+  if (has("ui", "component", "design", "tailwind", "shadcn")) {
+    return "UI components / design system — copy into your frontend";
+  }
+  if (has("docker", "kubernetes", "k8s", "devops", "deploy", "infra", "ci/cd")) {
+    return "DevOps / infra — study or adopt for ops";
+  }
+  if (has("security", "vuln", "exploit", "pentest", "hack", "fuzz")) {
+    return "Security tooling — defensive use / pentest practice";
+  }
+  if (has("game", "engine", "shader")) {
+    return "Game / graphics — study or fork";
+  }
+  if (has("awesome", "list", "resources", "tutorial", "course", "book")) {
+    return "Curated resources — bookmark for learning";
+  }
+  if (has("trading", "finance", "quant", "market")) {
+    return "Finance / trading tooling — study the strategies or self-host";
+  }
+  if (r.language === "Python") return "Python project — pip install and try";
+  if (r.language === "TypeScript" || r.language === "JavaScript") {
+    return "JS/TS project — npm install and try";
+  }
+  if (r.language === "Rust") return "Rust project — cargo add and try";
+  if (r.language === "Go") return "Go project — go install and try";
+  return "General-purpose project — read the README to see what fits";
+}
+
+function langEmoji(lang: string): string {
+  const map: Record<string, string> = {
+    Python: "🐍",
+    TypeScript: "🟦",
+    JavaScript: "🟨",
+    Rust: "🦀",
+    Go: "🐹",
+    Java: "☕",
+    Kotlin: "🟪",
+    Swift: "🟧",
+    "C++": "➕",
+    C: "🔵",
+    "C#": "🎯",
+    Ruby: "💎",
+    PHP: "🐘",
+    Shell: "🐚",
+    HTML: "🌐",
+    CSS: "🎨",
+    Vue: "🟢",
+    Svelte: "🟠",
+    Lua: "🌙",
+    Dart: "🎯",
+    Solidity: "💠",
+    Zig: "⚡",
+  };
+  return map[lang] ?? "🧩";
+}
+
+function rankEmoji(rank: number): string {
+  if (rank === 1) return "🥇";
+  if (rank === 2) return "🥈";
+  if (rank === 3) return "🥉";
+  return `#${rank}`;
 }
 
 function uniqueLanguages(repos: TrendingRepo[]): string[] {
@@ -175,4 +367,17 @@ function uniqueLanguages(repos: TrendingRepo[]): string[] {
     }
   }
   return out;
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1).trimEnd() + "…";
+}
+
+function capitalise(s: string): string {
+  return s.length === 0 ? s : s[0].toUpperCase() + s.slice(1);
+}
+
+function formatDate(d: Date): string {
+  return d.toISOString().slice(0, 10);
 }

--- a/sensors/sensor-github-trending/src/types.ts
+++ b/sensors/sensor-github-trending/src/types.ts
@@ -4,12 +4,12 @@ export const githubTrendingConfigSchema = z.object({
   /** Refresh cadence — controls both the GitHub `since=` window and the emit interval. */
   cadence: z.enum(["daily", "weekly"]).default("weekly"),
   /** How many repos to include in each digest signal. GitHub's page lists up to 25. */
-  top_n: z.number().int().min(1).max(25).default(10),
+  top_n: z.coerce.number().int().min(1).max(25).default(10),
   /**
    * If > 0, repos seen in any of the last N digests are skipped. Default 0 (always send).
    * Useful when the same repos linger on the trending list across cycles.
    */
-  dedupe_within_cycles: z.number().int().min(0).max(52).default(0),
+  dedupe_within_cycles: z.coerce.number().int().min(0).max(52).default(0),
 });
 
 export type GithubTrendingConfig = z.infer<typeof githubTrendingConfigSchema>;

--- a/sensors/sensor-github-trending/src/types.ts
+++ b/sensors/sensor-github-trending/src/types.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export const githubTrendingConfigSchema = z.object({
+  /** Refresh cadence — controls both the GitHub `since=` window and the emit interval. */
+  cadence: z.enum(["daily", "weekly"]).default("weekly"),
+  /** How many repos to include in each digest signal. GitHub's page lists up to 25. */
+  top_n: z.number().int().min(1).max(25).default(10),
+  /**
+   * If > 0, repos seen in any of the last N digests are skipped. Default 0 (always send).
+   * Useful when the same repos linger on the trending list across cycles.
+   */
+  dedupe_within_cycles: z.number().int().min(0).max(52).default(0),
+});
+
+export type GithubTrendingConfig = z.infer<typeof githubTrendingConfigSchema>;
+
+export interface TrendingRepo {
+  rank: number;
+  full_name: string;
+  author: string;
+  name: string;
+  url: string;
+  description: string;
+  language: string | null;
+  stars_total: number;
+  stars_gained_in_window: number;
+  forks: number;
+}

--- a/sensors/sensor-github-trending/tsconfig.json
+++ b/sensors/sensor-github-trending/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "composite": true,
+    "incremental": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
new sensor: github trending. uses the W2A SDK. daily / weekly cadence, top_n configurable (1–25), optional dedupe. no auth needed — just scrapes github.com/trending.

tested locally: smoke + 6s lifecycle (env-var config) + npm pack tarball install — all green.

per docs/CONTRIBUTING.md sensors don't strictly need a PR, but the package is scoped `@world2agent/...` so flagging here in case you want to merge + publish from the monorepo. happy to rename to my own scope and publish independently if that's preferred.

draft for now.