### PR TITLE
docs(skill): swap Codex → Hermes in supported runtimes

### DIFF
--- a/skills/build-w2a-sensor/SKILL.md
+++ b/skills/build-w2a-sensor/SKILL.md
@@ -324,7 +324,7 @@ export type <Name>Config = z.infer<typeof <name>ConfigSchema>;
 
 ## Phase 4 — Author SETUP.md (the install experience)
 
-`SETUP.md` is what the consumer agent reads when installing a sensor (via `/world2agent:sensor-add <package>` in Claude Code, or the equivalent skill/tool in Codex / OpenClaw). It must:
+`SETUP.md` is what the consumer agent reads when installing a sensor (via `/world2agent:sensor-add <package>` in Claude Code, or the equivalent skill/tool in Hermes / OpenClaw). It must:
 
 1. Describe the sensor in one paragraph.
 2. Declare every config parameter in a table (written to `~/.world2agent/config.json`).


### PR DESCRIPTION
## Summary

- `skills/build-w2a-sensor/SKILL.md` Phase 4 (line 327) referenced "Codex / OpenClaw" as the equivalent runtimes to Claude Code's `/world2agent:sensor-add` flow.
- Codex is not currently a supported W2A runtime — the README and Quick Start (since #7) document Claude Code, Hermes, and OpenClaw.
- This PR replaces `Codex` with `Hermes` so the skill reflects the actual runtime story authors are pointed at.

## Test plan

- [x] Diff is a single-word change in one Markdown file
- [x] No code paths or schema changed
- [x] Pre-push secret scan clean

## Follow-ups (not in this PR)

- The "Host channels" list at the end of SKILL.md still has only `@world2agent/claude-code-channel`. Hermes (`@world2agent/hermes-sensor-bridge`) and OpenClaw (`@world2agent/openclaw-sensor-bridge`) should likely be added too, and the section heading reconciled (channel vs bridge). Happy to ship that as a separate PR if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)