### PR TITLE
docs(quick-start): document reload_sensors for mid-session changes

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -28,6 +28,10 @@ Restart Claude Code with the plugin channel loaded so sensor signals can be deli
 claude --dangerously-load-development-channels plugin:world2agent@world2agent-plugins
 ```
 
+> **After changing your sensor set mid-session, call `reload_sensors`.**
+>
+> Whenever you run `/world2agent:sensor-add` or `/world2agent:sensor-remove`, or hand-edit `~/.world2agent/config.json`, ask Claude to call the `reload_sensors` MCP tool. It diffs the config file against the running set — new sensors start, removed sensors stop, config-changed sensors restart. No session restart needed. Without it, the host silently keeps running the old sensor set.
+
 Browse the full sensor catalog at [world2agent.ai/hub](https://world2agent.ai/hub).
 
 ## Option 2: Code — SDK + Sensor


### PR DESCRIPTION
## Summary
- Adds a callout in `docs/quick-start.md` (Option 1, Claude Code) explaining that after `/world2agent:sensor-add`, `/world2agent:sensor-remove`, or hand-editing `~/.world2agent/config.json`, users must ask Claude to call the `reload_sensors` MCP tool — otherwise the host silently keeps the old sensor set.
- Before this change, `reload_sensors` was only described in the MCP server's runtime instructions (surfaced as a system reminder). Grep confirms 0 markdown files in the repo mentioned it.

## Scope note
Issue #11 also suggested mentioning `reload_sensors` in `docs/multi-sensor.md` "near the config-editing example." On inspection, `multi-sensor.md` covers SDK programmatic composition (`runAll`, transports) and contains no `config.json`-editing example — that workflow is plugin-runtime-only and lives in `quick-start.md`. Inserting a `reload_sensors` note there would be off-topic for that document, so it was left untouched.

The optional runtime-side mtime-watching enhancement from #11 is out of scope for this docs-only PR and would belong in the plugin/MCP server repo.

Closes #11

## Test plan
- [x] `git diff` reviewed — only 4 lines added, no other changes
- [x] Markdown renders as a blockquote callout (GFM)
- [ ] Maintainer skim to confirm tone/placement match house style

🤖 Generated with [Claude Code](https://claude.com/claude-code)